### PR TITLE
Add a parameter for redefine the class that manage the admin dashboard

### DIFF
--- a/Resources/config/config.yml
+++ b/Resources/config/config.yml
@@ -1,3 +1,6 @@
+parameters:
+    bigfoot.dashboard_controller: Bigfoot\Bundle\CoreBundle\Controller\DashboardController
+
 twig:
     globals:
         bigfoot_version: '3.0'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -177,7 +177,7 @@ services:
             - { name: form.type, alias: bigfoot_bundle_corebundle_quicklinktype }
     # DoshBoardController
     bigfoot.dashboard:
-        class: Bigfoot\Bundle\CoreBundle\Controller\DashboardController
+        class: %bigfoot.dashboard_controller%
         calls:
             - [setContainer, ["@service_container"]]
         tags:


### PR DESCRIPTION
Default value for this new provided directly by the bundle and can be override in `config_admin.yml` after imports section
